### PR TITLE
Feat: Set commit status using GitHub REST API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Features
+
+## Notifications
+
+### Implementation
+The CI server sets the commit status on the repository using the GitHub REST API. Based on the results from the Black format check, the commit status is set to either  **pending**, **failure** or **success**. 
+
+### Test
+The notification feature is tested using **pytest** and **unittest.mock**. The test checks if the notification function sends a valid and correctly formatted request to the GitHub REST API. The test also checks if the function returns correctly based on the request's response. The function returns True if the status code of the response is 201, False otherwise. 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,13 @@ from fastapi import FastAPI, Request, HTTPException
 from src.black import run_black_format_check
 from src.git import clone_repo
 from src.pytest import run_pytest_test_suite
+from src.notification import create_commit_status, State
+
+# Repository settings
+owner = "DD2480-Group-15-vt24"
+repo = "2-CI"
+token = "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"
+
 
 app = FastAPI()
 
@@ -10,12 +17,16 @@ app = FastAPI()
 @app.post("/webhook/format/")
 async def webhook_format(request: Request):
     payload = await request.json()
+    sha = payload["head_commit"]["id"]
+    create_commit_status(owner, repo, sha, State.PENDING, token)
     repo_url = payload["repository"]["clone_url"]
     branch = payload["ref"].split("/")[-1]
     repo_dir = clone_repo(repo_url, branch)
     if run_black_format_check(repo_dir):
+        create_commit_status(owner, repo, sha, State.SUCCESS, token)
         return {"status": "formatting check passed"}
     else:
+        create_commit_status(owner, repo, sha, State.FAILURE, token)
         raise HTTPException(status_code=422, detail="formatting check failed")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pydantic==2.6.0
 pydantic_core==2.16.1
 pytest==7.4.4
 pytest-asyncio==0.23.4
+requests==2.31.0
 ruff==0.1.14
 smmap==5.0.1
 sniffio==1.3.0

--- a/src/notification.py
+++ b/src/notification.py
@@ -1,0 +1,38 @@
+import requests
+from enum import Enum
+
+
+class State(Enum):
+    ERROR = "error"
+    FAILURE = "failure"
+    PENDING = "pending"
+    SUCCESS = "success"
+
+
+def create_commit_status(
+    owner: str, repo: str, sha: str, state: State, token: str
+) -> bool:
+    """
+    Create a commit status for a given SHA.
+
+    :param owner: The account owner of the repository. The name is not case sensitive.
+    :param repo: The name of the repository without the .git extension. The name is not case sensitive.
+    :param sha: SHA for which the commit status is created
+    :param state: The state of the status.
+    :param target_url: The target URL to associate with this tatus.
+    :param token: Token for authenticating to the GitHub REST API
+    :return: True if commit status was successfully created, False otherwise
+    """
+
+    endpoint = f"https://api.github.com/repos/{owner}/{repo}/statuses/{sha}"
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+    }
+
+    payload = {"state": state.name}
+
+    response = requests.post(endpoint, headers=headers, json=payload)
+
+    return response.status_code == 201

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,0 +1,36 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from src.notification import create_commit_status, State
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_result",
+    [
+        (201, True),
+        (404, False),
+    ],
+)
+@patch("requests.post")
+def test_create_commit_status(mock_post, status_code, expected_result):
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_post.return_value = mock_response
+
+    owner = "owner"
+    repo = "repo"
+    sha = "1234"
+    state = State.SUCCESS
+    token = "token"
+
+    result = create_commit_status(owner, repo, sha, state, token)
+
+    assert result == expected_result
+
+    mock_post.assert_called_once_with(
+        f"https://api.github.com/repos/{owner}/{repo}/statuses/{sha}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+        },
+        json={"state": state.name},
+    )

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -64,6 +64,7 @@ def test_webhook_actions(
             json={
                 "repository": {"clone_url": "https://github.com/example/repo.git"},
                 "ref": "refs/heads/main",
+                "head_commit": {"id": "1234"},
             },
         )
         assert response.status_code == expected_status


### PR DESCRIPTION
- Implemented a function that creates a commit status for a specific commit. A commit status is created based on the result from webhook_format() i.e. the Black format check. API calls need parameters that are, for now, stored in main.py. 
- Imlemented a test for checking the format of the API request and if the function returns correctly (return value is currently not used).
- Wrote brief feature documentation.