### PR TITLE
Fix: Read API token from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+#GitHub API token
+src/token.txt

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,7 @@
 ### Implementation
 The CI server sets the commit status on the repository using the GitHub REST API. Based on the results from the Black format check, the commit status is set to either  **pending**, **failure** or **success**. 
 
+The CI server uses a token to authenticate to the API. An authentication token needs to be provided in *src/token.txt*.
+
 ### Test
 The notification feature is tested using **pytest** and **unittest.mock**. The test checks if the notification function sends a valid and correctly formatted request to the GitHub REST API. The test also checks if the function returns correctly based on the request's response. The function returns True if the status code of the response is 201, False otherwise. 

--- a/main.py
+++ b/main.py
@@ -8,8 +8,6 @@ from src.notification import create_commit_status, State
 # Repository settings
 owner = "DD2480-Group-15-vt24"
 repo = "2-CI"
-token = "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"
-
 
 app = FastAPI()
 
@@ -18,15 +16,15 @@ app = FastAPI()
 async def webhook_format(request: Request):
     payload = await request.json()
     sha = payload["head_commit"]["id"]
-    create_commit_status(owner, repo, sha, State.PENDING, token)
+    create_commit_status(owner, repo, sha, State.PENDING)
     repo_url = payload["repository"]["clone_url"]
     branch = payload["ref"].split("/")[-1]
     repo_dir = clone_repo(repo_url, branch)
     if run_black_format_check(repo_dir):
-        create_commit_status(owner, repo, sha, State.SUCCESS, token)
+        create_commit_status(owner, repo, sha, State.SUCCESS)
         return {"status": "formatting check passed"}
     else:
-        create_commit_status(owner, repo, sha, State.FAILURE, token)
+        create_commit_status(owner, repo, sha, State.FAILURE)
         raise HTTPException(status_code=422, detail="formatting check failed")
 
 

--- a/src/notification.py
+++ b/src/notification.py
@@ -1,4 +1,5 @@
 import requests
+import os
 from enum import Enum
 
 
@@ -9,9 +10,7 @@ class State(Enum):
     SUCCESS = "success"
 
 
-def create_commit_status(
-    owner: str, repo: str, sha: str, state: State, token: str
-) -> bool:
+def create_commit_status(owner: str, repo: str, sha: str, state: State) -> bool:
     """
     Create a commit status for a given SHA.
 
@@ -20,11 +19,12 @@ def create_commit_status(
     :param sha: SHA for which the commit status is created
     :param state: The state of the status.
     :param target_url: The target URL to associate with this tatus.
-    :param token: Token for authenticating to the GitHub REST API
     :return: True if commit status was successfully created, False otherwise
     """
 
     endpoint = f"https://api.github.com/repos/{owner}/{repo}/statuses/{sha}"
+
+    token = read_token_from_file("src/token.txt")
 
     headers = {
         "Accept": "application/vnd.github+json",
@@ -36,3 +36,21 @@ def create_commit_status(
     response = requests.post(endpoint, headers=headers, json=payload)
 
     return response.status_code == 201
+
+
+def read_token_from_file(filepath: str) -> str:
+    """
+    Read one line from a file.
+
+    :param filepath: Path to file
+    :return: The first line of the specified file
+    """
+    if os.path.exists(filepath):
+        file = open(filepath)
+        token = file.readline()
+        file.close()
+        return token
+    else:
+        raise Exception(
+            "No API token provided. Please create src/token.txt and provide the GitHub API token."
+        )

--- a/src/notification.py
+++ b/src/notification.py
@@ -18,7 +18,6 @@ def create_commit_status(owner: str, repo: str, sha: str, state: State) -> bool:
     :param repo: The name of the repository without the .git extension. The name is not case sensitive.
     :param sha: SHA for which the commit status is created
     :param state: The state of the status.
-    :param target_url: The target URL to associate with this tatus.
     :return: True if commit status was successfully created, False otherwise
     """
 

--- a/src/notification.py
+++ b/src/notification.py
@@ -50,6 +50,7 @@ def read_token_from_file(filepath: str) -> str:
         file.close()
         return token
     else:
-        raise Exception(
+        print(
             "No API token provided. Please create src/token.txt and provide the GitHub API token."
         )
+        return "NO_API_TOKEN"

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,6 +1,34 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from src.notification import create_commit_status, State
+from src.notification import create_commit_status, State, read_token_from_file
+
+
+@pytest.fixture
+def token_file(tmp_path):
+    """
+    Mock a token file
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    token_file = src_dir / "token.txt"
+    token_file.write_text("token")
+    return token_file
+
+
+def read_token_from_file_success(token_file):
+    """
+    Test reading a file that exists
+    """
+    token = read_token_from_file(token_file)
+    assert token == "token"
+
+
+def read_token_from_file_failure(tmp_path):
+    """
+    Test reading a file that does not exists
+    """
+    with pytest.raises(Exception):
+        read_token_from_file(tmp_path / "random.txt")
 
 
 @pytest.mark.parametrize(
@@ -11,7 +39,11 @@ from src.notification import create_commit_status, State
     ],
 )
 @patch("requests.post")
-def test_create_commit_status(mock_post, status_code, expected_result):
+def test_create_commit_status(mock_post, status_code, expected_result, tmp_path):
+    """
+    Test that API requests to create commit statuses are correctly formated.
+    Also, test that when receiving an API response, the function returns correctly based on response status code.
+    """
     mock_response = MagicMock()
     mock_response.status_code = status_code
     mock_post.return_value = mock_response

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -48,6 +48,11 @@ def test_create_commit_status(mock_post, status_code, expected_result, tmp_path)
     mock_response.status_code = status_code
     mock_post.return_value = mock_response
 
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    token_file = src_dir / "token.txt"
+    token_file.write_text("token")
+
     owner = "owner"
     repo = "repo"
     sha = "1234"

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -39,7 +39,7 @@ def read_token_from_file_failure(tmp_path):
     ],
 )
 @patch("requests.post")
-def test_create_commit_status(mock_post, status_code, expected_result, tmp_path):
+def test_create_commit_status(mock_post, status_code, expected_result):
     """
     Test that API requests to create commit statuses are correctly formated.
     Also, test that when receiving an API response, the function returns correctly based on response status code.
@@ -47,11 +47,6 @@ def test_create_commit_status(mock_post, status_code, expected_result, tmp_path)
     mock_response = MagicMock()
     mock_response.status_code = status_code
     mock_post.return_value = mock_response
-
-    src_dir = tmp_path / "src"
-    src_dir.mkdir()
-    token_file = src_dir / "token.txt"
-    token_file.write_text("token")
 
     owner = "owner"
     repo = "repo"

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -52,7 +52,7 @@ def test_create_commit_status(mock_post, status_code, expected_result):
     repo = "repo"
     sha = "1234"
     state = State.SUCCESS
-    token = "token"
+    token = "NO_API_TOKEN"
 
     result = create_commit_status(owner, repo, sha, state)
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -22,7 +22,7 @@ def test_create_commit_status(mock_post, status_code, expected_result):
     state = State.SUCCESS
     token = "token"
 
-    result = create_commit_status(owner, repo, sha, state, token)
+    result = create_commit_status(owner, repo, sha, state)
 
     assert result == expected_result
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -11,18 +11,6 @@ def client():
 
 
 @pytest.fixture
-def token_file(tmp_path):
-    """
-    Mock a token file
-    """
-    src_dir = tmp_path / "src"
-    src_dir.mkdir()
-    token_file = src_dir / "token.txt"
-    token_file.write_text("token")
-    return token_file
-
-
-@pytest.fixture
 def mock_clone_repo():
     with patch("main.clone_repo", return_value="/path/to/repo") as mock:
         yield mock
@@ -69,7 +57,12 @@ def test_webhook_actions(
     mock_return,
     expected_status,
     expected_response,
+    tmp_path,
 ):
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    token_file = src_dir / "token.txt"
+    token_file.write_text("token")
     with patch(mock_function_path, return_value=mock_return) as _mock_function:
         response = client.post(
             endpoint,

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -11,6 +11,18 @@ def client():
 
 
 @pytest.fixture
+def token_file(tmp_path):
+    """
+    Mock a token file
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    token_file = src_dir / "token.txt"
+    token_file.write_text("token")
+    return token_file
+
+
+@pytest.fixture
 def mock_clone_repo():
     with patch("main.clone_repo", return_value="/path/to/repo") as mock:
         yield mock

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -57,12 +57,7 @@ def test_webhook_actions(
     mock_return,
     expected_status,
     expected_response,
-    tmp_path,
 ):
-    src_dir = tmp_path / "src"
-    src_dir.mkdir()
-    token_file = src_dir / "token.txt"
-    token_file.write_text("token")
     with patch(mock_function_path, return_value=mock_return) as _mock_function:
         response = client.post(
             endpoint,


### PR DESCRIPTION
API token is now read from src/token.txt instead of being stored in main.py. Storing the API token in the repo is not possible. The token file needs to be created for the server to function correctly.
Added tests for file reader function.

Closes #24 