### PR TITLE
Fix: Add comments to function and classes in github.py

### DIFF
--- a/src/github.py
+++ b/src/github.py
@@ -6,6 +6,10 @@ GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "no-token")
 
 
 class State(Enum):
+    """
+    Types of commit status states
+    """
+
     ERROR = "error"
     FAILURE = "failure"
     PENDING = "pending"
@@ -13,6 +17,10 @@ class State(Enum):
 
 
 class CIType:
+    """
+    CI types
+    """
+
     FORMAT = {
         "context": "FORMAT",
         "description": "Formatting pipeline result",
@@ -27,6 +35,15 @@ class CIType:
 async def create_commit_status(
     owner: str, repo: str, sha: str, state: State, ci_type: CIType
 ) -> None:
+    """
+    Create a commit status for a given SHA
+
+    :param owner: The account owner of the repository. The name is not case sensitive.
+    :param repo: The name of the repository without the .git extension. The name is not case sensitive.
+    :param sha: SHA for which the commit status is created
+    :param state: The state of the status.
+    :param ci_type: The CI type
+    """
     url = f"https://api.github.com/repos/{owner}/{repo}/statuses/{sha}"
     headers = {
         "Authorization": f"token {GITHUB_TOKEN}",


### PR DESCRIPTION
Added missing comments to create_commit_status(), CITypes and State 